### PR TITLE
PODS-92: Audit events

### DIFF
--- a/app/audit/AuditEvent.scala
+++ b/app/audit/AuditEvent.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit
+
+trait AuditEvent {
+  def auditType: String
+}

--- a/app/audit/AuditService.scala
+++ b/app/audit/AuditService.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit
+
+import com.google.inject.{ImplementedBy, Inject}
+import config.AppConfig
+import play.api.Logger
+import play.api.libs.json.{JsString, Json, Writes}
+import play.api.mvc.RequestHeader
+import uk.gov.hmrc.play.HeaderCarrierConverter
+import uk.gov.hmrc.play.audit.AuditExtensions._
+import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.implicitConversions
+
+@ImplementedBy(classOf[AuditServiceImpl])
+trait AuditService {
+
+  def sendEvent[T <: AuditEvent](event: T)(implicit
+                                           rh: RequestHeader,
+                                           write: Writes[T],
+                                           ec: ExecutionContext): Future[AuditResult]
+
+}
+
+class AuditServiceImpl @Inject() (
+                             config: AppConfig,
+                             connector: AuditConnector
+                             ) extends AuditService {
+
+  private implicit def toHc(request: RequestHeader): AuditHeaderCarrier =
+    auditHeaderCarrier(HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session)))
+
+  def sendEvent[T <: AuditEvent](event: T)(implicit
+                                           rh: RequestHeader,
+                                           write: Writes[T],
+                                           ec: ExecutionContext): Future[AuditResult] = {
+
+    val eventJson = Json.obj(
+      "data" -> event
+    )
+
+    val details = rh.toAuditDetails().foldLeft(eventJson) {
+      case (m, (k, v)) =>
+        m + (k -> JsString(v))
+    }
+
+    Logger.debug(s"[AuditService][sendEvent] sending ${event.auditType}")
+
+    val result: Future[AuditResult] = connector.sendExtendedEvent(ExtendedDataEvent(
+      auditSource = config.appName,
+      auditType   = event.auditType,
+      tags        = rh.toAuditTags(
+        transactionName = event.auditType,
+        path            = rh.path
+      ),
+      detail      = details
+    ))
+
+    result.onSuccess {
+      case _ =>
+        Logger.debug(s"[AuditService][sendEvent] successfully sent ${event.auditType}")
+    }
+
+    result.onFailure {
+      case e =>
+        Logger.error(s"[AuditService][sendEvent] failed to send event ${event.auditType}", e)
+    }
+
+    result
+  }
+
+}

--- a/app/audit/PSARegistration.scala
+++ b/app/audit/PSARegistration.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit
+
+import play.api.libs.json.{Format, Json}
+
+case class PSARegistration(
+  withId: Boolean,
+  externalId: String,
+  psaType: String,
+  found: Boolean,
+  isUk: Option[Boolean]
+) extends AuditEvent {
+  override def auditType: String = "PSARegistration"
+}
+
+object PSARegistration {
+  implicit val formatsPSARegistration: Format[PSARegistration] = Json.format[PSARegistration]
+}

--- a/app/audit/PSASubscription.scala
+++ b/app/audit/PSASubscription.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit
+
+import play.api.libs.json.{Format, Json}
+
+case class PSASubscription(
+                          existingUser: Boolean,
+                          success: Boolean,
+                          legalStatus: String
+                          ) extends AuditEvent {
+  override def auditType: String = "PSASubscription"
+}
+
+object PSASubscription {
+  implicit val formatsPSASubscription: Format[PSASubscription] = Json.format[PSASubscription]
+}

--- a/app/audit/SchemeList.scala
+++ b/app/audit/SchemeList.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit
+
+import play.api.libs.json.{Format, Json}
+
+case class SchemeList(
+                     psaIdentifier: String
+                     )extends AuditEvent {
+  override def auditType: String = "SchemeList"
+}
+
+object SchemeList {
+  implicit val formatsSchemeList: Format[SchemeList] = Json.format[SchemeList]
+}

--- a/app/audit/SchemeSubscription.scala
+++ b/app/audit/SchemeSubscription.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit
+
+import play.api.libs.json.{Format, Json}
+
+case class SchemeSubscription(
+                               psaIdentifier: String,
+                               schemeType: SchemeType.Value,
+                               hasIndividualEstablisher: Boolean,
+                               hasCompanyEstablisher: Boolean,
+                               hasPartnershipEstablisher: Boolean,
+                               hasDormantCompany: Boolean,
+                               hasBankDetails: Boolean,
+                               hasValidBankDetails: Boolean
+                             ) extends AuditEvent {
+  override def auditType: String = "SchemeSubscription"
+}
+
+object SchemeSubscription {
+  implicit val formatsSchemeSubscription: Format[SchemeSubscription] = Json.format[SchemeSubscription]
+}

--- a/app/audit/SchemeType.scala
+++ b/app/audit/SchemeType.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit
+
+import play.api.libs.json.{Reads, Writes}
+
+object SchemeType extends Enumeration {
+  val singleTrust = Value("Single trust")
+  val groupLifeDeath = Value("Group life/death in service")
+  val bodyCorporate = Value("Body corporate")
+  val masterTrust = Value("Master trust")
+  val other = Value("Other")
+
+  implicit val reads: Reads[SchemeType.Value] = Reads.enumNameReads(SchemeType)
+  implicit val writes: Writes[SchemeType.Value] = Writes.enumNameWrites
+
+}

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -25,6 +25,7 @@ class AppConfig @Inject()(override val runModeConfiguration: Configuration, envi
 
   lazy val baseURL: String = baseUrl("des-hod")
   lazy val barsBaseUrl: String = baseUrl("bank-account-reputation")
+  lazy val appName: String = runModeConfiguration.underlying.getString("appName")
 
   lazy val schemeRegistrationUrl: String = s"$baseURL${runModeConfiguration.underlying.getString("serviceUrls.scheme.register")}"
   lazy val schemeAdminRegistrationUrl: String = s"$baseURL${runModeConfiguration.underlying.getString("serviceUrls.scheme.administrator.register")}"

--- a/app/controllers/SchemeController.scala
+++ b/app/controllers/SchemeController.scala
@@ -17,23 +17,20 @@
 package controllers
 
 import com.google.inject.Inject
-import connector.SchemeConnector
-import models.{ListOfSchemes, PensionSchemeAdministrator}
+import models.ListOfSchemes
+import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc._
 import service.SchemeService
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 import utils.ErrorHandler
-import play.api.Logger
-
-
 import utils.validationUtils._
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{Failure, Success, Try}
 
-class SchemeController @Inject()(schemeConnector: SchemeConnector, schemeService: SchemeService) extends BaseController with ErrorHandler {
+class SchemeController @Inject()(schemeService: SchemeService) extends BaseController with ErrorHandler {
 
   def registerScheme: Action[AnyContent] = Action.async {
     implicit request => {
@@ -55,21 +52,13 @@ class SchemeController @Inject()(schemeConnector: SchemeConnector, schemeService
   def registerPSA: Action[AnyContent] = Action.async {
     implicit request => {
       val feJson = request.body.asJson
-      Logger.debug(s"[PSA-Registration-Incoming-Payload]${feJson}")
+      Logger.debug(s"[PSA-Registration-Incoming-Payload]$feJson")
 
       feJson match {
         case Some(jsValue) =>
-          Try(jsValue.convertTo[PensionSchemeAdministrator](PensionSchemeAdministrator.apiReads)) match {
-            case Success(pensionSchemeAdministrator) =>
-              val psaJsValue = Json.toJson(pensionSchemeAdministrator)
-              Logger.debug(s"[PSA-Registration-Outgoing-Payload]${psaJsValue}")
-
-              schemeConnector.registerPSA(psaJsValue).map {
-                httpResponse => Ok(httpResponse.body)
-              }
-            case Failure(e) =>
-              Logger.warn(s"Bad Request returned from frontend for PSA $e")
-              Future.failed(new BadRequestException(s"Bad Request returned from frontend for PSA $e"))
+          schemeService.registerPSA(jsValue).map {
+            response =>
+              Ok(response.body)
           }
         case _ => Future.failed(new BadRequestException("Bad Request with no request body"))
       }
@@ -80,13 +69,14 @@ class SchemeController @Inject()(schemeConnector: SchemeConnector, schemeService
     implicit request => {
       val psaId = request.headers.get("psaId")
 
-      psaId match {
-        case Some(psa) =>
-          schemeConnector.listOfSchemes(psa).map { httpResponse =>
-            Ok(Json.toJson(httpResponse.json.convertTo[ListOfSchemes]))
-          }
-        case _ => Future.failed(new BadRequestException("Bad Request with no Psa Id"))
-      }
-    } recoverWith recoverFromError
+    psaId match {
+      case Some(psa) =>
+        schemeService.listOfSchemes(psa).map { httpResponse =>
+          Ok(Json.toJson(httpResponse.json.convertTo[ListOfSchemes]))
+        }
+      case _ => Future.failed(new BadRequestException("Bad Request with no Psa Id"))
+    }
+  } recoverWith recoverFromError
   }
+
 }

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import uk.gov.hmrc.auth.core.AffinityGroup
+
+case class User(externalId: String, affinityGroup: AffinityGroup)

--- a/app/service/SchemeServiceV1.scala
+++ b/app/service/SchemeServiceV1.scala
@@ -16,29 +16,48 @@
 
 package service
 
+import audit.{AuditService, PSASubscription, SchemeList, SchemeSubscription, SchemeType => AuditSchemeType}
 import com.google.inject.Inject
 import connector.{BarsConnector, SchemeConnector}
-import models._
 import models.PensionsScheme._
 import models.ReadsEstablisherDetails.readsEstablisherDetails
+import models._
+import models.enumeration.SchemeType
 import play.api.Logger
 import play.api.libs.json.{JsResultException, JsValue, Json}
+import play.api.mvc.RequestHeader
 import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpResponse}
+import utils.validationUtils._
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
-class SchemeServiceV1 @Inject()(schemeConnector: SchemeConnector, barsConnector: BarsConnector) extends SchemeService {
+class SchemeServiceV1 @Inject()(schemeConnector: SchemeConnector, barsConnector: BarsConnector, auditService: AuditService) extends SchemeService {
 
-  def registerScheme(psaId: String, json: JsValue)(implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
+  def registerScheme(psaId: String, json: JsValue)
+      (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext, request: RequestHeader): Future[HttpResponse] = {
 
     jsonToPensionsSchemeModel(json).fold(
       badRequestException => Future.failed(badRequestException),
       validPensionsScheme => {
         haveInvalidBank(json, validPensionsScheme).flatMap {
-          pensionsScheme => schemeConnector.registerScheme(psaId, Json.toJson(pensionsScheme))
+          case (pensionsScheme, hasBankDetails) => schemeConnector.registerScheme(psaId, Json.toJson(pensionsScheme)) andThen {
+            case Success(_) =>
+              sendSchemeSubscriptionEvent(psaId, pensionsScheme, hasBankDetails)
+          }
         }
       }
     )
+
+  }
+
+  def listOfSchemes(psaId: String)
+      (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext, request: RequestHeader): Future[HttpResponse] = {
+
+    schemeConnector.listOfSchemes(psaId) andThen {
+      case Success(_) =>
+        sendSchemeListEvent(psaId)
+    }
 
   }
 
@@ -64,16 +83,16 @@ class SchemeServiceV1 @Inject()(schemeConnector: SchemeConnector, barsConnector:
   }
 
   def haveInvalidBank(json: JsValue, pensionsScheme: PensionsScheme)
-                     (implicit ec: ExecutionContext, hc: HeaderCarrier): Future[PensionsScheme] = {
+                     (implicit ec: ExecutionContext, hc: HeaderCarrier): Future[(PensionsScheme, Boolean)] = {
 
     readBankAccount(json).fold(
       jsResultException => Future.failed(jsResultException),
       {
         case Some(bankAccount) => isBankAccountInvalid(bankAccount).map {
-          case true => pensionSchemeHaveInvalidBank.set(pensionsScheme, true)
-          case false => pensionsScheme
+          case true => (pensionSchemeHaveInvalidBank.set(pensionsScheme, true), true)
+          case false => (pensionsScheme, true)
         }
-        case None => Future.successful(pensionsScheme)
+        case None => Future.successful((pensionsScheme, false))
       }
     )
 
@@ -93,9 +112,83 @@ class SchemeServiceV1 @Inject()(schemeConnector: SchemeConnector, barsConnector:
   }
 
   private def isBankAccountInvalid(bankAccount: BankAccount)
-                                  (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[Boolean] = {
+      (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[Boolean] = {
 
     barsConnector.invalidBankAccount(bankAccount)
+
+  }
+
+  private def sendSchemeSubscriptionEvent(psaId: String, pensionsScheme: PensionsScheme, hasBankDetails: Boolean)
+      (implicit request: RequestHeader, ec: ExecutionContext): Unit = {
+
+    auditService.sendEvent(translateSchemeSubscriptionEvent(psaId, pensionsScheme, hasBankDetails))
+
+  }
+
+  def translateSchemeSubscriptionEvent(psaId: String, pensionsScheme: PensionsScheme, hasBankDetails: Boolean): SchemeSubscription = {
+
+    val schemeType = if (pensionsScheme.customerAndSchemeDetails.isSchemeMasterTrust) {
+      AuditSchemeType.masterTrust
+    }
+    else {
+      pensionsScheme.customerAndSchemeDetails.schemeStructure match {
+        case SchemeType.single.value => AuditSchemeType.singleTrust
+        case SchemeType.group.value => AuditSchemeType.groupLifeDeath
+        case SchemeType.corp.value => AuditSchemeType.bodyCorporate
+        case _ => AuditSchemeType.other
+      }
+    }
+
+    SchemeSubscription(
+      psaIdentifier = psaId,
+      schemeType = schemeType,
+      hasIndividualEstablisher = pensionsScheme.establisherDetails.exists(establisher => establisher.`type` == "Individual"),
+      hasCompanyEstablisher = pensionsScheme.establisherDetails.exists(establisher => establisher.`type` == "Company/Org"),
+      hasPartnershipEstablisher = pensionsScheme.establisherDetails.exists(establisher => establisher.`type` == "Partnership"),
+      hasDormantCompany = pensionsScheme.pensionSchemeDeclaration.box5.getOrElse(false),
+      hasBankDetails = hasBankDetails,
+      hasValidBankDetails = hasBankDetails && !pensionsScheme.customerAndSchemeDetails.haveInvalidBank
+    )
+
+  }
+
+  private def sendSchemeListEvent(psaId: String)(implicit request: RequestHeader, ec: ExecutionContext): Unit = {
+
+    auditService.sendEvent(SchemeList(psaId))
+
+  }
+
+  override def registerPSA(json: JsValue)
+                          (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext, request: RequestHeader): Future[HttpResponse] = {
+
+    Try(json.convertTo[PensionSchemeAdministrator](PensionSchemeAdministrator.apiReads)) match {
+      case Success(pensionSchemeAdministrator) =>
+        val psaJsValue = Json.toJson(pensionSchemeAdministrator)
+        Logger.debug(s"[PSA-Registration-Outgoing-Payload]$psaJsValue")
+
+        schemeConnector.registerPSA(psaJsValue) andThen {
+          case Success(_) =>
+            sendPSASubscriptionEvent(pensionSchemeAdministrator, true)
+          case _ =>
+            sendPSASubscriptionEvent(pensionSchemeAdministrator, false)
+        }
+
+      case Failure(e) =>
+        Logger.warn(s"Bad Request returned from frontend for PSA $e")
+        Future.failed(new BadRequestException(s"Bad Request returned from frontend for PSA $e"))
+    }
+
+  }
+
+  private def sendPSASubscriptionEvent(psa: PensionSchemeAdministrator, success: Boolean)(implicit request: RequestHeader, ec: ExecutionContext): Unit = {
+
+    auditService.sendEvent(
+      PSASubscription(
+        existingUser = psa.pensionSchemeAdministratoridentifierStatus.isExistingPensionSchemaAdministrator,
+        success = success,
+        legalStatus = psa.legalStatus
+      )
+    )
 
   }
 

--- a/conf/test.application.conf
+++ b/conf/test.application.conf
@@ -1,0 +1,31 @@
+# Copyright 2018 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include "application.conf"
+
+microservice {
+  metrics {
+    graphite {
+      enabled = false
+    }
+  }
+}
+
+metrics {
+  enabled = false
+}
+
+auditing {
+  enabled = false
+}

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -48,6 +48,8 @@ trait MicroService {
     .configs(IntegrationTest)
     .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)
     .settings(
+      fork in Test := true,
+      javaOptions in Test += "-Dconfig.file=conf/test.application.conf",
       Keys.fork in IntegrationTest := false,
       unmanagedSourceDirectories in IntegrationTest <<= (baseDirectory in IntegrationTest)(base => Seq(base / "it")),
       addTestReportOption(IntegrationTest, "int-test-reports"),

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -39,7 +39,7 @@ object MicroServiceBuild extends Build with MicroService {
 
   def test(scope: String = "test,it") = Seq(
     "uk.gov.hmrc" %% "hmrctest" % "3.0.0" % scope,
-    "org.scalatest" %% "scalatest" % "2.2.6" % scope,
+    "org.scalatest" %% "scalatest" % "3.0.4" % scope,
     "org.pegdown" % "pegdown" % "1.6.0" % scope,
     "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
     "org.scalatestplus.play" %% "scalatestplus-play" % scalaTestPlusPlayVersion % scope,

--- a/test/audit/AuditServiceSpec.scala
+++ b/test/audit/AuditServiceSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit
+
+import org.scalatest.{AsyncFlatSpec, Inside, Matchers}
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.{Format, JsDefined, JsString, Json}
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.http.config.AuditingConfig
+import uk.gov.hmrc.play.audit.http.connector.AuditResult.Disabled
+import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class AuditServiceSpec extends AsyncFlatSpec with Matchers with Inside {
+
+  import AuditServiceSpec._
+
+  "AuditServiceImpl" should "construct and send the correct event" in {
+
+    implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
+
+    val event = TestAuditEvent("test-audit-payload")
+
+    val result = auditService().sendEvent(event)
+    val sentEvent = FakeAuditConnector.lastSentEvent
+
+    result.map {
+      auditResult =>
+        auditResult shouldBe Disabled
+
+        inside(sentEvent) {
+          case ExtendedDataEvent(auditSource, auditType, _, _, detail, _) =>
+            auditSource shouldBe appName
+            auditType shouldBe "TestAuditEvent"
+            (detail \ "data" \ "payload") shouldBe JsDefined(JsString("test-audit-payload"))
+        }
+    }
+
+  }
+
+}
+
+object AuditServiceSpec {
+
+  private val app = new GuiceApplicationBuilder()
+    .overrides(
+      bind[AuditConnector].toInstance(FakeAuditConnector)
+    )
+    .build()
+
+  def fakeRequest(): FakeRequest[AnyContentAsEmpty.type] = FakeRequest("", "")
+
+  def auditService(): AuditService = app.injector.instanceOf[AuditService]
+
+  def appName: String = app.configuration.underlying.getString("appName")
+
+}
+
+//noinspection ScalaDeprecation
+object FakeAuditConnector extends AuditConnector {
+
+  private var sentEvent:ExtendedDataEvent = _
+
+  override def auditingConfig: AuditingConfig = AuditingConfig(None, false)
+
+  override def sendExtendedEvent(event: ExtendedDataEvent)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[AuditResult] = {
+    sentEvent = event
+    super.sendExtendedEvent(event)
+  }
+
+  def lastSentEvent: ExtendedDataEvent = sentEvent
+
+}
+
+case class TestAuditEvent(payload: String) extends AuditEvent {
+  override def auditType: String = "TestAuditEvent"
+}
+
+object TestAuditEvent {
+  implicit val formatsTestAuditEvent: Format[TestAuditEvent] = Json.format[TestAuditEvent]
+}

--- a/test/audit/testdoubles/StubSuccessfulAuditService.scala
+++ b/test/audit/testdoubles/StubSuccessfulAuditService.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit.testdoubles
+
+import audit.{AuditEvent, AuditService}
+import play.api.libs.json.Writes
+import play.api.mvc.RequestHeader
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
+
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
+
+class StubSuccessfulAuditService extends AuditService {
+
+  private val events: mutable.ListBuffer[AuditEvent] = mutable.ListBuffer()
+
+  override def sendEvent[T <: AuditEvent](event: T)
+      (implicit rh: RequestHeader, write: Writes[T], ec: ExecutionContext): Future[AuditResult] = {
+
+    events += event
+    Future.successful(AuditResult.Success)
+  }
+
+  def verifySent[T <: AuditEvent](event: T): Boolean = events.contains(event)
+
+  def verifyNothingSent(): Boolean = events.isEmpty
+
+  def reset(): Unit = {
+    events.clear()
+  }
+
+}

--- a/test/connector/RegistrationConnectorSpec.scala
+++ b/test/connector/RegistrationConnectorSpec.scala
@@ -16,8 +16,10 @@
 
 package connector
 
+import audit.PSARegistration
+import audit.testdoubles.StubSuccessfulAuditService
 import base.SpecBase
-import models.{OrganisationRegistrant, SuccessResponse}
+import models.{OrganisationRegistrant, SuccessResponse, User}
 import org.joda.time.LocalDate
 import org.mockito.Matchers
 import org.mockito.Matchers.any
@@ -26,8 +28,11 @@ import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.{PatienceConfiguration, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.mvc.{AnyContentAsEmpty, Request}
+import play.api.test.FakeRequest
 import play.mvc.Http.Status.OK
-import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.auth.core.AffinityGroup
+import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpResponse, NotFoundException}
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -35,18 +40,27 @@ import scala.concurrent.Future
 
 class RegistrationConnectorSpec extends SpecBase with MockitoSugar with BeforeAndAfter with PatienceConfiguration {
 
-  val httpClient = mock[HttpClient]
-  val registrationConnector = new RegistrationConnectorImpl(httpClient, appConfig)
-  implicit val hc = HeaderCarrier()
-  val failureResponse: JsObject = Json.obj(
+  private val httpClient = mock[HttpClient]
+
+  private val auditService = new StubSuccessfulAuditService()
+  private val registrationConnector = new RegistrationConnectorImpl(httpClient, appConfig, auditService)
+
+  private implicit val hc: HeaderCarrier = HeaderCarrier()
+  private implicit val request: Request[AnyContentAsEmpty.type ] = FakeRequest("", "")
+
+  private val failureResponse: JsObject = Json.obj(
     "code" -> "INVALID_PAYLOAD",
     "reason" -> "Submission has not passed validation. Invalid PAYLOAD"
   )
 
-  before(reset(httpClient))
+  before {
+    reset(httpClient)
+    auditService.reset()
+  }
 
   "register with id individual" must {
     "return OK when Des/ETMP returns successfully for Individual" in {
+      val user = User("test-external-id", AffinityGroup.Individual)
       val inputRequestData = Json.obj("regime" -> "PODS", "requiresNameMatch" -> false, "isAnAgent" -> false)
       val validSuccessResponse = readJsonFromFile("/data/validRegisterWithIdIndividualResponse.json")
 
@@ -58,7 +72,7 @@ class RegistrationConnectorSpec extends SpecBase with MockitoSugar with BeforeAn
             validSuccessResponse.as[SuccessResponse]))))
         )
 
-      val result = registrationConnector.registerWithIdIndividual("AB100100A", inputRequestData)
+      val result = registrationConnector.registerWithIdIndividual("AB100100A", user, inputRequestData)
       ScalaFutures.whenReady(result) { res =>
         res.status mustBe OK
         res.body mustEqual Json.prettyPrint(Json.toJson(validSuccessResponse.as[SuccessResponse]))
@@ -66,6 +80,7 @@ class RegistrationConnectorSpec extends SpecBase with MockitoSugar with BeforeAn
     }
 
     "throw BadRequest when DES/ETMP throws Bad Request" in {
+      val user = User("test-external-id", AffinityGroup.Individual)
       val invalidData = Json.obj("data" -> "invalid")
       val failureResponse = Json.obj("code" -> "INVALID_PAYLOAD",
         "reason" -> "Submission has not passed validation. Invalid PAYLOAD")
@@ -75,16 +90,92 @@ class RegistrationConnectorSpec extends SpecBase with MockitoSugar with BeforeAn
         Matchers.eq(invalidData), any())(any(), any(), any(), any())).thenReturn(
         Future.failed(new BadRequestException(failureResponse.toString())))
 
-      val result = registrationConnector.registerWithIdIndividual("AB100100A", invalidData)
+      val result = registrationConnector.registerWithIdIndividual("AB100100A", user, invalidData)
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[BadRequestException]
         e.getMessage mustEqual failureResponse.toString()
+      }
+    }
+
+    "send a PSARegistration audit event on success" in {
+      val user = User("test-external-id", AffinityGroup.Individual)
+      val inputRequestData = Json.obj("regime" -> "PODS", "requiresNameMatch" -> false, "isAnAgent" -> false)
+      val validSuccessResponse = readJsonFromFile("/data/validRegisterWithIdIndividualResponse.json")
+
+      when(httpClient.POST[JsValue, HttpResponse](
+        Matchers.eq(appConfig.registerWithIdIndividualUrl.format("AB100100A")),
+        Matchers.eq(inputRequestData), any())(any(), any(), any(), any())).
+        thenReturn(
+          Future.successful(HttpResponse(OK, Some(Json.toJson(
+            validSuccessResponse.as[SuccessResponse]))))
+        )
+
+      val result = registrationConnector.registerWithIdIndividual("AB100100A", user, inputRequestData)
+
+      ScalaFutures.whenReady(result) {
+        _ =>
+          auditService.verifySent(
+            PSARegistration(
+              withId = true,
+              externalId = user.externalId,
+              psaType = "Individual",
+              found = true,
+              isUk = Some(true)
+            )
+          ) mustBe true
+      }
+    }
+
+    "send a PSARegistration audit event on not found" in {
+      val user = User("test-external-id", AffinityGroup.Individual)
+      val invalidData = Json.obj("data" -> "invalid")
+      val failureResponse = Json.obj("code" -> "INVALID_PAYLOAD",
+        "reason" -> "Submission has not passed validation. Invalid PAYLOAD")
+
+      when(httpClient.POST[JsValue, HttpResponse](
+        Matchers.eq(appConfig.registerWithIdIndividualUrl.format("AB100100A")),
+        Matchers.eq(invalidData), any())(any(), any(), any(), any())).thenReturn(
+        Future.failed(new NotFoundException(failureResponse.toString())))
+
+      val result = registrationConnector.registerWithIdIndividual("AB100100A", user, invalidData)
+
+      ScalaFutures.whenReady(result.failed) {
+        _ =>
+          auditService.verifySent(
+            PSARegistration(
+              withId = true,
+              externalId = user.externalId,
+              psaType = "Individual",
+              found = false,
+              isUk = None
+            )
+          ) mustBe true
+      }
+    }
+
+    "not send a PSARegistration audit event on failure" in {
+      val user = User("test-external-id", AffinityGroup.Individual)
+      val invalidData = Json.obj("data" -> "invalid")
+      val failureResponse = Json.obj("code" -> "INVALID_PAYLOAD",
+        "reason" -> "Submission has not passed validation. Invalid PAYLOAD")
+
+      when(httpClient.POST[JsValue, HttpResponse](
+        Matchers.eq(appConfig.registerWithIdIndividualUrl.format("AB100100A")),
+        Matchers.eq(invalidData), any())(any(), any(), any(), any())).thenReturn(
+        Future.failed(new BadRequestException(failureResponse.toString())))
+
+      val result = registrationConnector.registerWithIdIndividual("AB100100A", user, invalidData)
+
+      ScalaFutures.whenReady(result.failed) {
+        _ =>
+          auditService.verifyNothingSent() mustBe true
       }
     }
   }
 
   "register with id organisation" must {
     "return OK when Des/ETMP returns successfully for Organisation" in {
+      val user = User("test-external-id", AffinityGroup.Organisation)
       val inputRequestData = Json.obj("regime" -> "PODS", "requiresNameMatch" -> true, "isAnAgent" -> false,
         "organisation" -> Json.obj(
           "organisationName" -> "Test Ltd",
@@ -97,7 +188,7 @@ class RegistrationConnectorSpec extends SpecBase with MockitoSugar with BeforeAn
         Matchers.eq(inputRequestData), any())(any(), any(), any(), any())).thenReturn(Future.successful(HttpResponse(OK, Some(Json.toJson(
         validSuccessResponse.as[SuccessResponse])))))
 
-      val result = registrationConnector.registerWithIdOrganisation("1100000000", inputRequestData)
+      val result = registrationConnector.registerWithIdOrganisation("1100000000", user, inputRequestData)
       ScalaFutures.whenReady(result) { res =>
         res.status mustBe OK
         res.body mustEqual Json.prettyPrint(Json.toJson(validSuccessResponse.as[SuccessResponse]))
@@ -105,6 +196,7 @@ class RegistrationConnectorSpec extends SpecBase with MockitoSugar with BeforeAn
     }
 
     "throw BadRequest when DES/ETMP throws Bad Request" in {
+      val user = User("test-external-id", AffinityGroup.Organisation)
       val invalidData = Json.obj("data" -> "invalid")
       val failureResponse = Json.obj("code" -> "INVALID_PAYLOAD",
         "reason" -> "Submission has not passed validation. Invalid PAYLOAD")
@@ -114,17 +206,99 @@ class RegistrationConnectorSpec extends SpecBase with MockitoSugar with BeforeAn
         Matchers.eq(invalidData), any())(any(), any(), any(), any())).thenReturn(
         Future.failed(new BadRequestException(failureResponse.toString())))
 
-      val result = registrationConnector.registerWithIdOrganisation("1100000000", invalidData)
+      val result = registrationConnector.registerWithIdOrganisation("1100000000", user, invalidData)
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[BadRequestException]
         e.getMessage mustEqual failureResponse.toString()
       }
     }
+
+    "send a PSARegistration audit event on success" in {
+      val user = User("test-external-id", AffinityGroup.Organisation)
+      val inputRequestData = Json.obj("regime" -> "PODS", "requiresNameMatch" -> true, "isAnAgent" -> false,
+        "organisation" -> Json.obj(
+          "organisationName" -> "Test Ltd",
+          "organisationType" -> "LLP"
+        ))
+      val validSuccessResponse = readJsonFromFile("/data/validRegisterWithIdOrganisationResponse.json")
+
+      when(httpClient.POST[JsValue, HttpResponse](
+        Matchers.eq(appConfig.registerWithIdOrganisationUrl.format("1100000000")),
+        Matchers.eq(inputRequestData), any())(any(), any(), any(), any())).thenReturn(Future.successful(HttpResponse(OK, Some(Json.toJson(
+        validSuccessResponse.as[SuccessResponse])))))
+
+      val result = registrationConnector.registerWithIdOrganisation("1100000000", user, inputRequestData)
+
+      ScalaFutures.whenReady(result) {
+        _ =>
+          auditService.verifySent(
+            PSARegistration(
+              withId = true,
+              externalId = user.externalId,
+              psaType = "LLP",
+              found = true,
+              isUk = Some(true)
+            )
+          ) mustBe true
+      }
+    }
+
+    "send a PSARegistration audit event on not found" in {
+      val user = User("test-external-id", AffinityGroup.Organisation)
+      val inputRequestData = Json.obj("regime" -> "PODS", "requiresNameMatch" -> true, "isAnAgent" -> false,
+        "organisation" -> Json.obj(
+          "organisationName" -> "Test Ltd",
+          "organisationType" -> "LLP"
+        ))
+      val failureResponse = Json.obj("code" -> "INVALID_PAYLOAD",
+        "reason" -> "Submission has not passed validation. Invalid PAYLOAD")
+
+      when(httpClient.POST[JsValue, HttpResponse](
+        Matchers.eq(appConfig.registerWithIdOrganisationUrl.format("1100000000")),
+        Matchers.eq(inputRequestData), any())(any(), any(), any(), any()))
+        .thenReturn(Future.failed(new NotFoundException(failureResponse.toString())))
+
+      val result = registrationConnector.registerWithIdOrganisation("1100000000", user, inputRequestData)
+
+      ScalaFutures.whenReady(result.failed) {
+        _ =>
+          auditService.verifySent(
+            PSARegistration(
+              withId = true,
+              externalId = user.externalId,
+              psaType = "LLP",
+              found = false,
+              isUk = None
+            )
+          ) mustBe true
+      }
+    }
+
+    "not send a PSARegistration audit event on failure" in {
+      val user = User("test-external-id", AffinityGroup.Organisation)
+      val invalidData = Json.obj("data" -> "invalid")
+      val failureResponse = Json.obj("code" -> "INVALID_PAYLOAD",
+        "reason" -> "Submission has not passed validation. Invalid PAYLOAD")
+
+      when(httpClient.POST[JsValue, HttpResponse](
+        Matchers.eq(appConfig.registerWithIdOrganisationUrl.format("1100000000")),
+        Matchers.eq(invalidData), any())(any(), any(), any(), any())).thenReturn(
+        Future.failed(new BadRequestException(failureResponse.toString())))
+
+      val result = registrationConnector.registerWithIdOrganisation("1100000000", user, invalidData)
+
+      ScalaFutures.whenReady(result.failed) {
+        _ =>
+          auditService.verifyNothingSent() mustBe true
+      }
+    }
+
   }
 
   "Register organisation no ID" must {
     val url = appConfig.registerWithoutIdOrganisationUrl
     "return OK when DES/Etmp returns successfully" in {
+      val user = User("test-external-id", AffinityGroup.Organisation)
       val validDataRequest = readJsonFromFile("/data/validRegistrationNoIDOrganisationFE.json").as[OrganisationRegistrant]
       val successResponse = Json.obj(
         "processingDate" -> LocalDate.now,
@@ -135,22 +309,86 @@ class RegistrationConnectorSpec extends SpecBase with MockitoSugar with BeforeAn
       when(httpClient.POST[OrganisationRegistrant, HttpResponse](Matchers.eq(url), Matchers.eq(validDataRequest), any())(any(), any(), any(), any())).
         thenReturn(Future.successful(HttpResponse(OK, Some(successResponse))))
 
-      val result = registrationConnector.registrationNoIdOrganisation(validDataRequest)
+      val result = registrationConnector.registrationNoIdOrganisation(user, validDataRequest)
       ScalaFutures.whenReady(result) {
         res =>
           res.status mustBe OK
       }
     }
+
     "throw BadRequestException when Etmp throws Bad Request" in {
+      val user = User("test-external-id", AffinityGroup.Organisation)
       val validDataRequest = readJsonFromFile("/data/validRegistrationNoIDOrganisationFE.json").as[OrganisationRegistrant]
       when(httpClient.POST[OrganisationRegistrant, HttpResponse](Matchers.eq(url), Matchers.eq(validDataRequest), any())(any(), any(), any(), any())).
         thenReturn(Future.failed(new BadRequestException(failureResponse.toString())))
 
-      val result = registrationConnector.registrationNoIdOrganisation(validDataRequest)
+      val result = registrationConnector.registrationNoIdOrganisation(user, validDataRequest)
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[BadRequestException]
         e.getMessage mustBe failureResponse.toString()
       }
     }
+
+    "send a PSARegistration audit event on success" in {
+      val user = User("test-external-id", AffinityGroup.Organisation)
+      val validDataRequest = readJsonFromFile("/data/validRegistrationNoIDOrganisationFE.json").as[OrganisationRegistrant]
+      val successResponse = Json.obj(
+        "processingDate" -> LocalDate.now,
+        "sapNumber" -> "1234567890",
+        "safeId" -> "XE0001234567890"
+      )
+
+      when(httpClient.POST[OrganisationRegistrant, HttpResponse](Matchers.eq(url), Matchers.eq(validDataRequest), any())(any(), any(), any(), any())).
+        thenReturn(Future.successful(HttpResponse(OK, Some(successResponse))))
+
+      val result = registrationConnector.registrationNoIdOrganisation(user, validDataRequest)
+      ScalaFutures.whenReady(result) {
+        _ =>
+          auditService.verifySent(
+            PSARegistration(
+              withId = false,
+              externalId = user.externalId,
+              psaType = "Organisation",
+              found = true,
+              isUk = Some(false)
+            )
+          ) mustBe true
+      }
+    }
+
+    "send a PSARegistration audit event on not found" in {
+      val user = User("test-external-id", AffinityGroup.Organisation)
+      val validDataRequest = readJsonFromFile("/data/validRegistrationNoIDOrganisationFE.json").as[OrganisationRegistrant]
+      when(httpClient.POST[OrganisationRegistrant, HttpResponse](Matchers.eq(url), Matchers.eq(validDataRequest), any())(any(), any(), any(), any())).
+        thenReturn(Future.failed(new NotFoundException(failureResponse.toString())))
+
+      val result = registrationConnector.registrationNoIdOrganisation(user, validDataRequest)
+      ScalaFutures.whenReady(result.failed) {
+        _ =>
+          auditService.verifySent(
+            PSARegistration(
+              withId = false,
+              externalId = user.externalId,
+              psaType = "Organisation",
+              found = false,
+              isUk = None
+            )
+          ) mustBe true
+      }
+    }
+
+    "not send a PSARegistration audit event on failure" in {
+      val user = User("test-external-id", AffinityGroup.Organisation)
+      val validDataRequest = readJsonFromFile("/data/validRegistrationNoIDOrganisationFE.json").as[OrganisationRegistrant]
+      when(httpClient.POST[OrganisationRegistrant, HttpResponse](Matchers.eq(url), Matchers.eq(validDataRequest), any())(any(), any(), any(), any())).
+        thenReturn(Future.failed(new BadRequestException(failureResponse.toString())))
+
+      val result = registrationConnector.registrationNoIdOrganisation(user, validDataRequest)
+      ScalaFutures.whenReady(result.failed) {
+        _ =>
+          auditService.verifyNothingSent() mustBe true
+      }
+    }
   }
+
 }

--- a/test/controllers/RegistrationControllerSpec.scala
+++ b/test/controllers/RegistrationControllerSpec.scala
@@ -22,46 +22,81 @@ import connector.RegistrationConnector
 import models._
 import org.joda.time.LocalDate
 import org.mockito.Matchers
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
+import play.api.libs.json._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import org.mockito.Mockito._
-import org.mockito.Matchers._
-import org.scalatest.BeforeAndAfter
-import play.api.libs.json.{JsNull, JsObject, JsValue, Json}
-import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.auth.core.authorise.Predicate
-import uk.gov.hmrc.auth.core.retrieve.{Retrieval, Retrievals}
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve._
 import uk.gov.hmrc.http._
+import utils.FakeAuthConnector
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 class RegistrationControllerSpec extends SpecBase with MockitoSugar with BeforeAndAfter {
 
-  val dataFromFrontend = readJsonFromFile("/data/validRegistrationNoIDOrganisationFE.json")
-  val dataToEmtp = readJsonFromFile("/data/validRegistrationNoIDOrganisationToEMTP.json").as[OrganisationRegistrant]
+  private val dataFromFrontend = readJsonFromFile("/data/validRegistrationNoIDOrganisationFE.json")
+  private val dataToEmtp = readJsonFromFile("/data/validRegistrationNoIDOrganisationToEMTP.json").as[OrganisationRegistrant]
+  private val nino = "test-nino"
+  private val externalId = "test-external-id"
+  private val fakeRequest = FakeRequest("POST", "/")
 
-  val fakeRequest = FakeRequest("POST", "/")
+  private val mockRegistrationConnector = mock[RegistrationConnector]
 
-  val mockRegistrationConnector = mock[RegistrationConnector]
+  private val individualRetrievals =
+    Future.successful(
+      new ~(
+        new ~(
+          Some(nino),
+          Some(externalId)
+        ),
+        Some(AffinityGroup.Individual)
+      )
+    )
 
-  def registrationController(authNino: Option[String] = Some("AB100100A")): RegistrationController = new RegistrationController(
-    new FakeAuthConnector(authNino), mockRegistrationConnector)
+  private val individualNoNinoRetrievals =
+    Future.successful(
+      new ~(
+        new ~(
+          None,
+          Some(externalId)
+        ),
+        Some(AffinityGroup.Individual)
+      )
+    )
+
+  private val organisationRetrievals =
+    Future.successful(
+      new ~(
+        Some(externalId),
+        Some(AffinityGroup.Organisation)
+      )
+    )
+
+  private def registrationController(retrievals: Future[_]): RegistrationController =
+    new RegistrationController(
+      new FakeAuthConnector(retrievals),
+      mockRegistrationConnector
+    )
 
   before(reset(mockRegistrationConnector))
+
   implicit val mat: Materializer = app.materializer
 
   "register With Id Individual" must {
     val inputRequestData = Json.obj("regime" -> "PODS", "requiresNameMatch" -> false, "isAnAgent" -> false)
     "return OK when the registration with id is successful for Individual" in {
-      val output = readJsonFromFile("/data/validRegisterWithIdIndividualResponse.json")
       val successResponse = Json.toJson(readJsonFromFile("/data/validRegisterWithIdIndividualResponse.json").as[SuccessResponse])
-      when(mockRegistrationConnector.registerWithIdIndividual(Matchers.eq("AB100100A"), Matchers.eq(inputRequestData))(
-        any(), any())).thenReturn(Future.successful(HttpResponse(OK, Some(output))))
+      when(mockRegistrationConnector.registerWithIdIndividual(Matchers.eq(nino), any(), Matchers.eq(inputRequestData))(
+        any(), any(), any())).thenReturn(Future.successful(HttpResponse(OK, Some(successResponse))))
 
-      val result = registrationController().registerWithIdIndividual(fakeRequest.withJsonBody(inputRequestData))
-      ScalaFutures.whenReady(result) { res =>
+      val result = registrationController(individualRetrievals).registerWithIdIndividual(fakeRequest.withJsonBody(inputRequestData))
+
+      ScalaFutures.whenReady(result) { _ =>
         status(result) mustBe OK
         contentAsJson(result) mustEqual successResponse
       }
@@ -69,66 +104,66 @@ class RegistrationControllerSpec extends SpecBase with MockitoSugar with BeforeA
 
     "throw BadRequestException when the bad data returned in the response from DES/ETMP" in {
       val output = Json.obj("bad" -> "data")
-      when(mockRegistrationConnector.registerWithIdIndividual(Matchers.eq("AB100100A"), Matchers.eq(inputRequestData))(
-        any(), any())).thenReturn(Future.successful(HttpResponse(OK, Some(output))))
+      when(mockRegistrationConnector.registerWithIdIndividual(Matchers.eq(nino), any(), Matchers.eq(inputRequestData))(
+        any(), any(), any())).thenReturn(Future.successful(HttpResponse(OK, Some(output))))
 
-      val result = registrationController().registerWithIdIndividual(fakeRequest.withJsonBody(inputRequestData))
+      val result = registrationController(individualRetrievals).registerWithIdIndividual(fakeRequest.withJsonBody(inputRequestData))
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[BadRequestException]
       }
     }
 
     "return Upstream4XXResponse when auth record does not contain Nino" in {
-      val result = registrationController(None).registerWithIdIndividual(fakeRequest.withJsonBody(inputRequestData))
+      val result = registrationController(individualNoNinoRetrievals).registerWithIdIndividual(fakeRequest.withJsonBody(inputRequestData))
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[Upstream4xxResponse]
         e.getMessage mustBe "Nino not found in auth record"
-        verify(mockRegistrationConnector, never()).registerWithIdIndividual(any(), any())(any(), any())
+        verify(mockRegistrationConnector, never()).registerWithIdIndividual(any(), any(), any())(any(), any(), any())
       }
     }
 
     "throw Upstream4xxResponse when DES/ETMP returns Upstream4xxResponse" in {
       val failureResponse = Json.obj("code" -> "INVALID_PAYLOAD",
         "reason" -> "Submission has not passed validation. Invalid PAYLOAD")
-      when(mockRegistrationConnector.registerWithIdIndividual(Matchers.eq("AB100100A"),
-        Matchers.eq(inputRequestData))(any(), any())).
-        thenReturn(Future.failed(new Upstream4xxResponse(failureResponse.toString(), CONFLICT, CONFLICT)))
+      when(mockRegistrationConnector.registerWithIdIndividual(Matchers.eq(nino), any(),
+        Matchers.eq(inputRequestData))(any(), any(), any())).
+        thenReturn(Future.failed(Upstream4xxResponse(failureResponse.toString(), CONFLICT, CONFLICT)))
 
-      val result = registrationController().registerWithIdIndividual(fakeRequest.withJsonBody(inputRequestData))
+      val result = registrationController(individualRetrievals).registerWithIdIndividual(fakeRequest.withJsonBody(inputRequestData))
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[Upstream4xxResponse]
         e.getMessage mustBe failureResponse.toString()
-        verify(mockRegistrationConnector, times(1)).registerWithIdIndividual(Matchers.eq("AB100100A"),
-          Matchers.eq(inputRequestData))(any(), any())
+        verify(mockRegistrationConnector, times(1)).registerWithIdIndividual(Matchers.eq(nino), any(),
+          Matchers.eq(inputRequestData))(any(), any(), any())
       }
     }
 
     "throw Upstream5xxResponse when DES/ETMP returns Upstream5xxResponse" in {
       val failureResponse = Json.obj("code" -> "SERVER_ERROR",
         "reason" -> "DES is currently experiencing problems that require live service intervention.")
-      when(mockRegistrationConnector.registerWithIdIndividual(Matchers.eq("AB100100A"),
-        Matchers.eq(inputRequestData))(any(), any())).thenReturn(
-        Future.failed(new Upstream5xxResponse(failureResponse.toString(), INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR)))
+      when(mockRegistrationConnector.registerWithIdIndividual(Matchers.eq(nino), any(),
+        Matchers.eq(inputRequestData))(any(), any(), any())).thenReturn(
+        Future.failed(Upstream5xxResponse(failureResponse.toString(), INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR)))
 
-      val result = registrationController().registerWithIdIndividual(fakeRequest.withJsonBody(inputRequestData))
+      val result = registrationController(individualRetrievals).registerWithIdIndividual(fakeRequest.withJsonBody(inputRequestData))
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[Upstream5xxResponse]
         e.getMessage mustBe failureResponse.toString()
-        verify(mockRegistrationConnector, times(1)).registerWithIdIndividual(Matchers.eq("AB100100A"),
-          Matchers.eq(inputRequestData))(any(), any())
+        verify(mockRegistrationConnector, times(1)).registerWithIdIndividual(Matchers.eq(nino), any(),
+          Matchers.eq(inputRequestData))(any(), any(), any())
       }
     }
 
     "throw generic exception when any other exception returned from Des" in {
-      when(mockRegistrationConnector.registerWithIdIndividual(Matchers.eq("AB100100A"),
-        Matchers.eq(inputRequestData))(Matchers.any(), Matchers.any())).thenReturn(Future.failed(new Exception("Generic Exception")))
+      when(mockRegistrationConnector.registerWithIdIndividual(Matchers.eq(nino), any(),
+        Matchers.eq(inputRequestData))(Matchers.any(), Matchers.any(), any())).thenReturn(Future.failed(new Exception("Generic Exception")))
 
-      val result = registrationController().registerWithIdIndividual(fakeRequest.withJsonBody(inputRequestData))
+      val result = registrationController(individualRetrievals).registerWithIdIndividual(fakeRequest.withJsonBody(inputRequestData))
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[Exception]
         e.getMessage mustBe "Generic Exception"
         verify(mockRegistrationConnector, times(1)).registerWithIdIndividual(
-          Matchers.eq("AB100100A"), Matchers.eq(inputRequestData))(any(), any())
+          Matchers.eq(nino), any(), Matchers.eq(inputRequestData))(any(), any(), any())
       }
     }
   }
@@ -138,11 +173,11 @@ class RegistrationControllerSpec extends SpecBase with MockitoSugar with BeforeA
     "return OK when the registration with id is successful for Organisation" in {
       val input = readJsonFromFile("/data/validRegisterWithIdOrganisationResponse.json")
       val successResponse = Json.toJson(readJsonFromFile("/data/validRegisterWithIdOrganisationResponse.json").as[SuccessResponse])
-      when(mockRegistrationConnector.registerWithIdOrganisation(Matchers.eq("1100000000"), any())(
-        any(), any())).thenReturn(Future.successful(HttpResponse(OK, Some(input))))
+      when(mockRegistrationConnector.registerWithIdOrganisation(Matchers.eq("1100000000"), any(), any())(
+        any(), any(), any())).thenReturn(Future.successful(HttpResponse(OK, Some(input))))
 
-      val result = registrationController().registerWithIdOrganisation(fakeRequest.withJsonBody(inputData))
-      ScalaFutures.whenReady(result) { res =>
+      val result = registrationController(organisationRetrievals).registerWithIdOrganisation(fakeRequest.withJsonBody(inputData))
+      ScalaFutures.whenReady(result) { _ =>
         status(result) mustBe OK
         contentAsJson(result) mustEqual successResponse
       }
@@ -151,14 +186,14 @@ class RegistrationControllerSpec extends SpecBase with MockitoSugar with BeforeA
     "return Bad Request when the bad data returned from frontend in the request" in {
       val inputData = Json.obj("bad" -> "data")
 
-      val result = registrationController().registerWithIdOrganisation(fakeRequest.withJsonBody(inputData))
+      val result = registrationController(organisationRetrievals).registerWithIdOrganisation(fakeRequest.withJsonBody(inputData))
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[BadRequestException]
       }
     }
 
     "return Bad Request when there is no body in the request" in {
-      val result = registrationController().registerWithIdOrganisation(fakeRequest)
+      val result = registrationController(organisationRetrievals).registerWithIdOrganisation(fakeRequest)
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[BadRequestException]
         e.getMessage mustEqual "No request body received for Organisation"
@@ -168,45 +203,45 @@ class RegistrationControllerSpec extends SpecBase with MockitoSugar with BeforeA
     "throw Upstream4xxResponse when DES/ETMP returns Upstream4xxResponse" in {
       val failureResponse = Json.obj("code" -> "INVALID_PAYLOAD",
         "reason" -> "Submission has not passed validation. Invalid PAYLOAD")
-      when(mockRegistrationConnector.registerWithIdOrganisation(Matchers.eq("1100000000"),
-        any())(any(), any())).
-        thenReturn(Future.failed(new Upstream4xxResponse(failureResponse.toString(), CONFLICT, CONFLICT)))
+      when(mockRegistrationConnector.registerWithIdOrganisation(Matchers.eq("1100000000"), any(),
+        any())(any(), any(), any())).
+        thenReturn(Future.failed(Upstream4xxResponse(failureResponse.toString(), CONFLICT, CONFLICT)))
 
-      val result = registrationController().registerWithIdOrganisation(fakeRequest.withJsonBody(inputData))
+      val result = registrationController(organisationRetrievals).registerWithIdOrganisation(fakeRequest.withJsonBody(inputData))
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[Upstream4xxResponse]
         e.getMessage mustBe failureResponse.toString()
-        verify(mockRegistrationConnector, times(1)).registerWithIdOrganisation(Matchers.eq("1100000000"),
-          any())(any(), any())
+        verify(mockRegistrationConnector, times(1)).registerWithIdOrganisation(Matchers.eq("1100000000"), any(),
+          any())(any(), any(), any())
       }
     }
 
     "throw Upstream5xxResponse when DES/ETMP returns Upstream5xxResponse" in {
       val failureResponse = Json.obj("code" -> "SERVER_ERROR",
         "reason" -> "DES is currently experiencing problems that require live service intervention.")
-      when(mockRegistrationConnector.registerWithIdOrganisation(Matchers.eq("1100000000"),
-        any())(any(), any())).thenReturn(
-        Future.failed(new Upstream5xxResponse(failureResponse.toString(), INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR)))
+      when(mockRegistrationConnector.registerWithIdOrganisation(Matchers.eq("1100000000"), any(),
+        any())(any(), any(), any())).thenReturn(
+        Future.failed(Upstream5xxResponse(failureResponse.toString(), INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR)))
 
-      val result = registrationController().registerWithIdOrganisation(fakeRequest.withJsonBody(inputData))
+      val result = registrationController(organisationRetrievals).registerWithIdOrganisation(fakeRequest.withJsonBody(inputData))
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[Upstream5xxResponse]
         e.getMessage mustBe failureResponse.toString()
-        verify(mockRegistrationConnector, times(1)).registerWithIdOrganisation(Matchers.eq("1100000000"),
-          any())(any(), any())
+        verify(mockRegistrationConnector, times(1)).registerWithIdOrganisation(Matchers.eq("1100000000"), any(),
+          any())(any(), any(), any())
       }
     }
 
     "throw generic exception when any other exception returned from Des" in {
-      when(mockRegistrationConnector.registerWithIdOrganisation(Matchers.eq("1100000000"),
-        any())(Matchers.any(), Matchers.any())).thenReturn(Future.failed(new Exception("Generic Exception")))
+      when(mockRegistrationConnector.registerWithIdOrganisation(Matchers.eq("1100000000"), any(),
+        any())(Matchers.any(), Matchers.any(), any())).thenReturn(Future.failed(new Exception("Generic Exception")))
 
-      val result = registrationController().registerWithIdOrganisation(fakeRequest.withJsonBody(inputData))
+      val result = registrationController(organisationRetrievals).registerWithIdOrganisation(fakeRequest.withJsonBody(inputData))
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[Exception]
         e.getMessage mustBe "Generic Exception"
         verify(mockRegistrationConnector, times(1)).registerWithIdOrganisation(
-          Matchers.eq("1100000000"), any())(any(), any())
+          Matchers.eq("1100000000"), any(), any())(any(), any(), any())
       }
     }
   }
@@ -219,30 +254,23 @@ class RegistrationControllerSpec extends SpecBase with MockitoSugar with BeforeA
         "sapNumber" -> "1234567890",
         "safeId" -> "XE0001234567890"
       )
-      when(mockRegistrationConnector.registrationNoIdOrganisation(Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any())).thenReturn(
+      when(mockRegistrationConnector.registrationNoIdOrganisation(any(), Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any(), any())).thenReturn(
         Future.successful(HttpResponse(OK, Some(successResponse))))
 
-      val result = call(registrationController().registrationNoIdOrganisation, fakeRequest(dataFromFrontend))
-      ScalaFutures.whenReady(result) { res =>
+      val result = call(registrationController(organisationRetrievals).registrationNoIdOrganisation, fakeRequest(dataFromFrontend))
+
+      ScalaFutures.whenReady(result) { _ =>
         status(result) mustBe OK
-        verify(mockRegistrationConnector, times(1)).registrationNoIdOrganisation(Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any())
+        verify(mockRegistrationConnector, times(1)).registrationNoIdOrganisation(any(), Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any(), any())
       }
     }
 
-    "throw BadRequestException when no data is present in the request" in {
-      val result = call(registrationController().registrationNoIdOrganisation, FakeRequest("POST", "/").withBody(JsNull))
-      ScalaFutures.whenReady(result.failed) { e =>
-        e mustBe a[BadRequestException]
-        verify(mockRegistrationConnector, never()).registrationNoIdOrganisation(Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any())
-      }
-    }
+    "throw BadRequestException when no data is not present in the request" in {
+      val result = call(registrationController(organisationRetrievals).registrationNoIdOrganisation, FakeRequest("POST", "/").withBody(JsNull))
 
-    "throw BadRequestException when bad data received in request from frontend" in {
-      val dataFromFrontend = Json.obj("bad" -> "data")
-      val result = call(registrationController().registrationNoIdOrganisation, fakeRequest(dataFromFrontend))
-      ScalaFutures.whenReady(result.failed) { e =>
-        e mustBe a[BadRequestException]
-        verify(mockRegistrationConnector, never()).registrationNoIdOrganisation(Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any())
+      ScalaFutures.whenReady(result) { _ =>
+        status(result) mustBe BAD_REQUEST
+        verify(mockRegistrationConnector, never()).registrationNoIdOrganisation(any(), Matchers.any())(Matchers.any(), Matchers.any(), any())
       }
     }
 
@@ -251,14 +279,15 @@ class RegistrationControllerSpec extends SpecBase with MockitoSugar with BeforeA
         "code" -> "INVALID_PAYLOAD",
         "reason" -> "Submission has not passed validation. Invalid PAYLOAD"
       )
-      when(mockRegistrationConnector.registrationNoIdOrganisation(Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any())).thenReturn(
+      when(mockRegistrationConnector.registrationNoIdOrganisation(any(), Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any(), any())).thenReturn(
         Future.failed(new BadRequestException(invalidPayload.toString())))
 
-      val result = call(registrationController().registrationNoIdOrganisation,fakeRequest(dataFromFrontend))
+      val result = call(registrationController(organisationRetrievals).registrationNoIdOrganisation,fakeRequest(dataFromFrontend))
+
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[BadRequestException]
         e.getMessage mustBe invalidPayload.toString()
-        verify(mockRegistrationConnector, times(1)).registrationNoIdOrganisation(Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any())
+        verify(mockRegistrationConnector, times(1)).registrationNoIdOrganisation(any(), Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any(), any())
       }
     }
 
@@ -267,14 +296,15 @@ class RegistrationControllerSpec extends SpecBase with MockitoSugar with BeforeA
         "code" -> "INVALID_SUBMISSION",
         "reason" -> "Duplicate submission acknowledgement reference from remote endpoint returned."
       )
-      when(mockRegistrationConnector.registrationNoIdOrganisation(Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any())).thenReturn(
-        Future.failed(new Upstream4xxResponse(invalidSubmission.toString(), CONFLICT, CONFLICT)))
+      when(mockRegistrationConnector.registrationNoIdOrganisation(any(), Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any(), any())).thenReturn(
+        Future.failed(Upstream4xxResponse(invalidSubmission.toString(), CONFLICT, CONFLICT)))
 
-      val result = call(registrationController().registrationNoIdOrganisation,fakeRequest(dataFromFrontend))
+      val result = call(registrationController(organisationRetrievals).registrationNoIdOrganisation,fakeRequest(dataFromFrontend))
+
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[Upstream4xxResponse]
         e.getMessage mustBe invalidSubmission.toString()
-        verify(mockRegistrationConnector, times(1)).registrationNoIdOrganisation(Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any())
+        verify(mockRegistrationConnector, times(1)).registrationNoIdOrganisation(any(), Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any(), any())
       }
     }
 
@@ -283,38 +313,30 @@ class RegistrationControllerSpec extends SpecBase with MockitoSugar with BeforeA
         "code" -> "SERVICE_UNAVAILABLE",
         "reason" -> "Dependent systems are currently not responding."
       )
-      when(mockRegistrationConnector.registrationNoIdOrganisation(Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any())).thenReturn(
-        Future.failed(new Upstream5xxResponse(serviceUnavailable.toString(), INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR)))
+      when(mockRegistrationConnector.registrationNoIdOrganisation(any(), Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any(), any())).thenReturn(
+        Future.failed(Upstream5xxResponse(serviceUnavailable.toString(), INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR)))
 
-      val result = call(registrationController().registrationNoIdOrganisation,fakeRequest(dataFromFrontend))
+      val result = call(registrationController(organisationRetrievals).registrationNoIdOrganisation,fakeRequest(dataFromFrontend))
+
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[Upstream5xxResponse]
         e.getMessage mustBe serviceUnavailable.toString()
-        verify(mockRegistrationConnector, times(1)).registrationNoIdOrganisation(Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any())
+        verify(mockRegistrationConnector, times(1)).registrationNoIdOrganisation(any(), Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any(), any())
       }
     }
 
     "throw generic exception when any other exception returned from Des" in {
-      when(mockRegistrationConnector.registrationNoIdOrganisation(Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any())).thenReturn(
+      when(mockRegistrationConnector.registrationNoIdOrganisation(any(), Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any(), any())).thenReturn(
         Future.failed(new Exception("Generic Exception")))
 
-      val result = call(registrationController().registrationNoIdOrganisation,fakeRequest(dataFromFrontend))
+      val result = call(registrationController(organisationRetrievals).registrationNoIdOrganisation,fakeRequest(dataFromFrontend))
+
       ScalaFutures.whenReady(result.failed) { e =>
         e mustBe a[Exception]
         e.getMessage mustBe "Generic Exception"
-        verify(mockRegistrationConnector, times(1)).registrationNoIdOrganisation(Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any())
+        verify(mockRegistrationConnector, times(1)).registrationNoIdOrganisation(any(), Matchers.eq(dataToEmtp))(Matchers.any(), Matchers.any(), any())
       }
     }
-
-
   }
-}
 
-class FakeAuthConnector(authNino: Option[String]) extends AuthConnector {
-  def success: Option[String] = authNino
-
-  override def authorise[A](predicate: Predicate, retrieval: Retrieval[A])(
-    implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] = {
-    Future.successful(success.asInstanceOf[A])
-  }
 }

--- a/test/service/SchemeServiceV1Spec.scala
+++ b/test/service/SchemeServiceV1Spec.scala
@@ -16,12 +16,19 @@
 
 package service
 
+import audit.testdoubles.StubSuccessfulAuditService
+import audit.{PSASubscription, SchemeList, SchemeSubscription, SchemeType => AuditSchemeType}
 import connector.{BarsConnector, SchemeConnector}
 import models._
+import models.enumeration.SchemeType
+import org.joda.time.LocalDate
 import org.scalatest.{AsyncFlatSpec, Matchers}
 import play.api.http.Status
 import play.api.libs.json._
+import play.api.mvc.{AnyContentAsEmpty, RequestHeader}
+import play.api.test.FakeRequest
 import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpResponse}
+import utils.Lens
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -33,9 +40,10 @@ class SchemeServiceV1Spec extends AsyncFlatSpec with Matchers {
 
     val json = bankDetailsJson(invalidAccountNumber)
 
-    schemeService.haveInvalidBank(json, pensionsScheme).map {
-      result =>
-        result.customerAndSchemeDetails.haveInvalidBank shouldBe true
+    testFixture().schemeService.haveInvalidBank(json, pensionsScheme).map {
+      case (scheme, hasBankDetails) =>
+        scheme.customerAndSchemeDetails.haveInvalidBank shouldBe true
+        hasBankDetails shouldBe true
     }
 
   }
@@ -44,9 +52,10 @@ class SchemeServiceV1Spec extends AsyncFlatSpec with Matchers {
 
     val json = bankDetailsJson(notInvalidAccountNumber)
 
-    schemeService.haveInvalidBank(json, pensionsScheme).map {
-      result =>
-        result.customerAndSchemeDetails.haveInvalidBank shouldBe false
+    testFixture().schemeService.haveInvalidBank(json, pensionsScheme).map {
+      case (scheme, hasBankDetails) =>
+        scheme.customerAndSchemeDetails.haveInvalidBank shouldBe false
+        hasBankDetails shouldBe true
     }
 
   }
@@ -55,9 +64,10 @@ class SchemeServiceV1Spec extends AsyncFlatSpec with Matchers {
 
     val json = Json.obj()
 
-    schemeService.haveInvalidBank(json, pensionsScheme).map {
-      result =>
-        result.customerAndSchemeDetails.haveInvalidBank shouldBe false
+    testFixture().schemeService.haveInvalidBank(json, pensionsScheme).map {
+      case (scheme, hasBankDetails) =>
+        scheme.customerAndSchemeDetails.haveInvalidBank shouldBe false
+        hasBankDetails shouldBe false
     }
 
   }
@@ -69,26 +79,26 @@ class SchemeServiceV1Spec extends AsyncFlatSpec with Matchers {
     )
 
     recoverToSucceededIf[BadRequestException] {
-      schemeService.haveInvalidBank(json, pensionsScheme)
+      testFixture().schemeService.haveInvalidBank(json, pensionsScheme)
     }
 
   }
 
   "jsonToPensionsSchemeModel" should "return a pensions scheme object given valid JSON" in {
 
-    schemeService.jsonToPensionsSchemeModel(pensionsSchemeJson) shouldBe a[Right[_, PensionsScheme]]
+    testFixture().schemeService.jsonToPensionsSchemeModel(pensionsSchemeJson) shouldBe a[Right[_, PensionsScheme]]
 
   }
 
   it should "return a BadRequestException if the JSON is invalid" in {
 
-    schemeService.jsonToPensionsSchemeModel(Json.obj()) shouldBe a[Left[BadRequestException, _]]
+    testFixture().schemeService.jsonToPensionsSchemeModel(Json.obj()) shouldBe a[Left[BadRequestException, _]]
 
   }
 
   "registerScheme" should "return the result of submitting the pensions scheme" in {
 
-    schemeService.registerScheme("test-psa-id", pensionsSchemeJson).map {
+    testFixture().schemeService.registerScheme(psaId, pensionsSchemeJson).map {
       response =>
         response.status shouldBe Status.OK
         val json = Json.parse(response.body)
@@ -97,14 +107,256 @@ class SchemeServiceV1Spec extends AsyncFlatSpec with Matchers {
 
   }
 
+  it should "send a SchemeSubscription audit event following a successful submission" in {
+
+    val fixture = testFixture()
+
+    val expected = schemeSubscription.copy(hasIndividualEstablisher = true)
+
+    fixture.schemeService.registerScheme(psaId, pensionsSchemeJson).map {
+      _ =>
+        fixture.auditService.verifySent(expected) shouldBe true
+    }
+
+  }
+
+  it should "not send a SchemeSubscription audit event following an unsuccessful submission" in {
+
+    val fixture = testFixture()
+
+    fixture.schemeConnector.setRegisterSchemeResponse(Future.failed(new BadRequestException("bad request")))
+
+    fixture.schemeService.registerScheme(psaId, pensionsSchemeJson)
+        .map(_ => fail("Expected failure"))
+        .recover {
+          case _: BadRequestException =>
+            fixture.auditService.verifyNothingSent() shouldBe true
+        }
+
+  }
+
+  "translateSchemeSubscriptionEvent" should "translate a master trust scheme" in {
+
+    val scheme = PensionsSchemeIsSchemeMasterTrust.set(pensionsScheme, true)
+    val actual = testFixture().schemeService.translateSchemeSubscriptionEvent(psaId, scheme, false)
+    val expected = schemeSubscription.copy(schemeType = AuditSchemeType.masterTrust)
+
+    actual shouldBe expected
+
+  }
+
+  it should "translate a single trust scheme" in {
+
+    val scheme = PensionsSchemeSchemeStructure.set(pensionsScheme, SchemeType.single.value)
+    val actual = testFixture().schemeService.translateSchemeSubscriptionEvent(psaId, scheme, false)
+    val expected = schemeSubscription
+
+    actual shouldBe expected
+
+  }
+
+  it should "translate a group Life/Death scheme" in {
+
+    val scheme = PensionsSchemeSchemeStructure.set(pensionsScheme, SchemeType.group.value)
+    val actual = testFixture().schemeService.translateSchemeSubscriptionEvent(psaId, scheme, false)
+    val expected = schemeSubscription.copy(schemeType = AuditSchemeType.groupLifeDeath)
+
+    actual shouldBe expected
+
+  }
+
+  it should "translate a body corporate scheme" in {
+
+    val scheme = PensionsSchemeSchemeStructure.set(pensionsScheme, SchemeType.corp.value)
+    val actual = testFixture().schemeService.translateSchemeSubscriptionEvent(psaId, scheme, false)
+    val expected = schemeSubscription.copy(schemeType = AuditSchemeType.bodyCorporate)
+
+    actual shouldBe expected
+
+  }
+
+  it should "translate an 'other' scheme" in {
+
+    val scheme = PensionsSchemeSchemeStructure.set(pensionsScheme, SchemeType.other.value)
+    val actual = testFixture().schemeService.translateSchemeSubscriptionEvent(psaId, scheme, false)
+    val expected = schemeSubscription.copy(schemeType = AuditSchemeType.other)
+
+    actual shouldBe expected
+
+  }
+
+  it should "translate a scheme with individual establishers" in {
+
+    val scheme =
+      PensionsSchemeSchemeStructure
+        .set(pensionsScheme, SchemeType.single.value)
+        .copy(establisherDetails = List(establisherDetails("Individual")))
+    val actual = testFixture().schemeService.translateSchemeSubscriptionEvent(psaId, scheme, false)
+    val expected = schemeSubscription.copy(hasIndividualEstablisher = true)
+
+    actual shouldBe expected
+
+  }
+
+  it should "translate a scheme with company establishers" in {
+
+    val scheme =
+      PensionsSchemeSchemeStructure
+        .set(pensionsScheme, SchemeType.single.value)
+        .copy(establisherDetails = List(establisherDetails("Company/Org")))
+    val actual = testFixture().schemeService.translateSchemeSubscriptionEvent(psaId, scheme, false)
+    val expected = schemeSubscription.copy(hasCompanyEstablisher = true)
+
+    actual shouldBe expected
+
+  }
+
+  it should "translate a scheme with partnership establishers" in {
+
+    val scheme =
+      PensionsSchemeSchemeStructure
+        .set(pensionsScheme, SchemeType.single.value)
+        .copy(establisherDetails = List(establisherDetails("Partnership")))
+    val actual = testFixture().schemeService.translateSchemeSubscriptionEvent(psaId, scheme, false)
+    val expected = schemeSubscription.copy(hasPartnershipEstablisher = true)
+
+    actual shouldBe expected
+
+  }
+
+  it should "translate a scheme with dormant company, bank details, and invalid bank details" in {
+
+    val scheme = pensionsScheme.copy(
+      customerAndSchemeDetails = pensionsScheme.customerAndSchemeDetails.copy(haveInvalidBank = true),
+      pensionSchemeDeclaration = pensionsScheme.pensionSchemeDeclaration.copy(box5 = Some(true))
+    )
+
+    val actual = testFixture().schemeService.translateSchemeSubscriptionEvent(psaId, scheme, true)
+
+    val expected = schemeSubscription.copy(
+      schemeType = AuditSchemeType.singleTrust,
+      hasDormantCompany = true,
+      hasBankDetails = true,
+      hasValidBankDetails = false
+    )
+
+    actual shouldBe expected
+
+  }
+
+  "listOfSchemes" should "return the list of schemes from the connector" in {
+
+    testFixture().schemeService.listOfSchemes(psaId).map {
+      httpResponse =>
+        httpResponse.status shouldBe Status.OK
+        httpResponse.json shouldBe listOfSchemesJson
+    }
+
+  }
+
+  it should "send an audit event on success" in {
+
+    val fixture = testFixture()
+
+    fixture.schemeService.listOfSchemes(psaId).map {
+      _ =>
+        fixture.auditService.verifySent(SchemeList(psaId)) shouldBe true
+    }
+
+  }
+
+  it should "not send on audit event on failure" in {
+
+    val fixture = testFixture()
+
+    fixture.schemeConnector.setListOfSchemesResponse(Future.failed(new BadRequestException("bad request")))
+
+    fixture.schemeService.listOfSchemes(psaId)
+      .map(_ => fail("Expected failure"))
+      .recover {
+        case _: BadRequestException =>
+          fixture.auditService.verifyNothingSent() shouldBe true
+      }
+
+  }
+
+  "registerPSA" should "return the result from the connector" in {
+
+    val fixture = testFixture()
+
+    fixture.schemeService.registerPSA(psaJson).map {
+      httpResponse =>
+        httpResponse.status shouldBe Status.OK
+        httpResponse.json shouldBe registerPsaResponseJson
+    }
+
+  }
+
+  it should "throw BadRequestException if the JSON cannot be parsed as PensionSchemeAdministrator" in {
+
+    val fixture = testFixture()
+
+    recoverToSucceededIf[BadRequestException] {
+      fixture.schemeService.registerPSA(Json.obj())
+    }
+
+  }
+
+  it should "send an audit event on success" in {
+
+    val fixture = testFixture()
+
+    fixture.schemeService.registerPSA(psaJson).map {
+      _ =>
+        fixture.auditService.verifySent(
+          PSASubscription(
+            existingUser = false,
+            success = true,
+            legalStatus = "test-legal-status"
+          )
+        ) shouldBe true
+    }
+
+  }
+
+  it should "send an audit event on failure" in {
+
+    val fixture = testFixture()
+
+    fixture.schemeConnector.setRegisterPsaResponse(Future.failed(new BadRequestException("bad request")))
+
+    fixture.schemeService.registerPSA(psaJson)
+      .map(_ => fail("Expected failure"))
+      .recover {
+        case _: BadRequestException =>
+          fixture.auditService.verifySent(
+            PSASubscription(
+              existingUser = false,
+              success = false,
+              legalStatus = "test-legal-status"
+            )
+          ) shouldBe true
+      }
+
+  }
+
+}
+
+class TestFixture {
+  val schemeConnector: FakeSchemeConnector = new FakeSchemeConnector()
+  val barsConnector: FakeBarsConnector = new FakeBarsConnector()
+  val auditService: StubSuccessfulAuditService = new StubSuccessfulAuditService()
+  val schemeService: SchemeServiceV1 = new SchemeServiceV1(schemeConnector, barsConnector, auditService)
 }
 
 object SchemeServiceV1Spec {
 
-  val schemeService: SchemeServiceV1 = new SchemeServiceV1(FakeSchemeConnector, FakeBarsConnector)
+  def testFixture(): TestFixture = new TestFixture()
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
+  implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("", "")
 
+  val psaId: String = "test-psa-id"
   val invalidAccountNumber: String = "111"
   val notInvalidAccountNumber: String = "112"
 
@@ -112,7 +364,7 @@ object SchemeServiceV1Spec {
     "schemeDetails" -> Json.obj(
       "schemeName" -> "test-scheme-name",
       "schemeType" -> Json.obj(
-        "name" -> "single"
+        "name" -> SchemeType.single.name
       )
     ),
     "membership" -> "opt1",
@@ -150,7 +402,7 @@ object SchemeServiceV1Spec {
     CustomerAndSchemeDetails(
       schemeName = "test-pensions-scheme",
       isSchemeMasterTrust = false,
-      schemeStructure = "test-scheme-structure",
+      schemeStructure = SchemeType.single.value,
       currentSchemeMembers = "test-current-scheme-members",
       futureSchemeMembers = "test-future-scheme-members",
       isReguledSchemeInvestment = false,
@@ -189,24 +441,112 @@ object SchemeServiceV1Spec {
   val schemeRegistrationResponse = SchemeRegistrationResponse("test-processing-date", "test-scheme-reference-number")
   val schemeRegistrationResponseJson: JsValue = Json.toJson(schemeRegistrationResponse)
 
+  val schemeSubscription = SchemeSubscription(
+    psaIdentifier = psaId,
+    schemeType = AuditSchemeType.singleTrust,
+    hasIndividualEstablisher = false,
+    hasCompanyEstablisher = false,
+    hasPartnershipEstablisher = false,
+    hasDormantCompany = false,
+    hasBankDetails = false,
+    hasValidBankDetails = false
+  )
+
+  def establisherDetails(establisherType: String): EstablisherDetails =
+    EstablisherDetails(
+      `type` = establisherType,
+      correspondenceAddressDetails = CorrespondenceAddressDetails(
+        addressDetails = UkAddress(
+          addressLine1 = "test-address-line-1",
+          countryCode = "test-country-code",
+          postalCode = "test-postal-code"
+        )
+      ),
+      correspondenceContactDetails = CorrespondenceContactDetails(
+        contactDetails = ContactDetails(
+          telephone = "test-telephone",
+          email = "test-email"
+        )
+      )
+    )
+
+  val listOfSchemes: ListOfSchemes =
+    ListOfSchemes(
+      processingDate = "1969-07-20",
+      totalSchemesRegistered = "0",
+      schemeDetail = None
+    )
+
+  val listOfSchemesJson: JsValue = Json.toJson(listOfSchemes)
+
+  val psaJson: JsValue = Json.obj(
+    "registrationInfo" -> Json.obj(
+      "legalStatus" -> "test-legal-status",
+      "sapNumber" -> "test-sap-number",
+      "noIdentifier" -> false,
+      "customerType" -> "test-customer-type"
+    ),
+    "individualContactDetails" -> Json.obj(
+      "phone" -> "test-phone",
+      "email" -> "test-email"
+    ),
+    "individualAddress" -> Json.obj(
+      "addressLine1" -> "test-address-line-1",
+      "countryCode" -> "GB",
+      "postalCode" -> "test-postal-code"
+    ),
+    "individualAddressYears" -> "test-individual-address-years",
+    "existingPSA" -> Json.obj(
+      "isExistingPSA" -> false
+    ),
+    "individualDetails" -> Json.obj(
+      "firstName" -> "test-first-name",
+      "lastName" -> "test-last-name",
+      "dateOfBirth" -> "2000-01-01"
+    ),
+    "declaration" -> true,
+    "declarationWorkingKnowledge" -> "test-declaration-working-knowledge",
+    "declarationFitAndProper" -> true
+  )
+
+  val registerPsaResponseJson: JsValue =
+    Json.obj(
+      "processingDate" -> LocalDate.now,
+      "formBundle" -> "1121313",
+      "psaId" -> "A21999999"
+    )
+
 }
 
-//noinspection NotImplementedCode
-object FakeSchemeConnector extends SchemeConnector {
+class FakeSchemeConnector extends SchemeConnector {
 
-  import SchemeServiceV1Spec.schemeRegistrationResponseJson
+  import SchemeServiceV1Spec.{listOfSchemesJson, registerPsaResponseJson, schemeRegistrationResponseJson}
 
-  override def registerScheme(psaId: String, registerData: JsValue)(implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
-    Future.successful(HttpResponse(Status.OK, Some(schemeRegistrationResponseJson)))
-  }
+  private var registerSchemeResponse = Future.successful(HttpResponse(Status.OK, Some(schemeRegistrationResponseJson)))
+  private var listOfSchemesResponse = Future.successful(HttpResponse(Status.OK, Some(listOfSchemesJson)))
+  private var registerPsaResponse = Future.successful(HttpResponse(Status.OK, Some(registerPsaResponseJson)))
 
-  override def registerPSA(registerData: JsValue)(implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = ???
+  def setRegisterSchemeResponse(response: Future[HttpResponse]): Unit = this.registerSchemeResponse = response
+  def setListOfSchemesResponse(response: Future[HttpResponse]): Unit = this.listOfSchemesResponse = response
+  def setRegisterPsaResponse(response: Future[HttpResponse]): Unit = this.registerPsaResponse = response
 
-  override def listOfSchemes(psaId: String)(implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = ???
+  override def registerScheme(psaId: String, registerData: JsValue)(implicit
+                                                        headerCarrier: HeaderCarrier,
+                                                        ec: ExecutionContext,
+                                                        request: RequestHeader): Future[HttpResponse] = registerSchemeResponse
 
+  override def registerPSA(registerData: JsValue)(implicit
+                                         headerCarrier: HeaderCarrier,
+                                         ec: ExecutionContext,
+                                         request: RequestHeader): Future[HttpResponse] = registerPsaResponse
+
+  override def listOfSchemes(psaId: String)(implicit
+                                   headerCarrier: HeaderCarrier,
+                                   ec: ExecutionContext,
+                                   request: RequestHeader): Future[HttpResponse] = listOfSchemesResponse
 }
 
-object FakeBarsConnector extends BarsConnector {
+class FakeBarsConnector extends BarsConnector {
 
   import SchemeServiceV1Spec._
 
@@ -224,4 +564,22 @@ case class SchemeRegistrationResponse(processingDate: String, schemeReferenceNum
 
 object SchemeRegistrationResponse {
   implicit val formatsSchemeRegistrationResponse: Format[SchemeRegistrationResponse] = Json.format[SchemeRegistrationResponse]
+}
+
+object PensionsSchemeIsSchemeMasterTrust extends Lens[PensionsScheme, Boolean] {
+
+  override def get: PensionsScheme => Boolean = pensionsScheme => pensionsScheme.customerAndSchemeDetails.isSchemeMasterTrust
+
+  override def set: (PensionsScheme, Boolean) => PensionsScheme = (pensionsScheme, isSchemeMasterTrust) =>
+    pensionsScheme.copy(customerAndSchemeDetails = pensionsScheme.customerAndSchemeDetails.copy(isSchemeMasterTrust = isSchemeMasterTrust))
+
+}
+
+object PensionsSchemeSchemeStructure extends Lens[PensionsScheme, String] {
+
+  override def get: PensionsScheme => String = pensionsScheme => pensionsScheme.customerAndSchemeDetails.schemeStructure
+
+  override def set: (PensionsScheme, String) => PensionsScheme = (pensionsScheme, schemeStructure) =>
+    pensionsScheme.copy(customerAndSchemeDetails = pensionsScheme.customerAndSchemeDetails.copy(schemeStructure = schemeStructure))
+
 }

--- a/test/utils/FakeAuthConnector.scala
+++ b/test/utils/FakeAuthConnector.scala
@@ -14,23 +14,20 @@
  * limitations under the License.
  */
 
-package service
+package utils
 
-import play.api.libs.json._
-import play.api.mvc.RequestHeader
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
+import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait SchemeService {
+class FakeAuthConnector(stubbedResult: Future[_]) extends AuthConnector {
 
-  def registerScheme(psaId: String, json: JsValue)
-      (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext, request: RequestHeader): Future[HttpResponse]
-
-  def listOfSchemes(psaId: String)
-      (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext, request: RequestHeader): Future[HttpResponse]
-
-  def registerPSA(json: JsValue)
-      (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext, request: RequestHeader): Future[HttpResponse]
+  override def authorise[A](predicate: Predicate, retrieval: Retrieval[A])
+                           (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] = {
+    stubbedResult.map(_.asInstanceOf[A])
+  }
 
 }


### PR DESCRIPTION
Added logging to Audit Service

Added initial set up for PSA Registration events

Adding case classes for PSAReg, SchemeSub and SchemeList

Updated enumerations for audit events for cleaner data

Refactoiring enum objects into files and updating controller to use correct models

Adding scheme events

Compiles

Extracted AuditService trait

Commit to rebase

Fixes after rebase

SchemeSubscription

SchemeList

PSARegistration

Fixes after rebase

PSASubscription

Fix failing test

Tidy up

Delete unused types