### PR TITLE
Prev address detail fix

### DIFF
--- a/app/controllers/SchemeController.scala
+++ b/app/controllers/SchemeController.scala
@@ -61,7 +61,7 @@ class SchemeController @Inject()(schemeConnector: SchemeConnector, schemeService
         case Some(jsValue) =>
           Try(jsValue.convertTo[PensionSchemeAdministrator](PensionSchemeAdministrator.apiReads)) match {
             case Success(pensionSchemeAdministrator) =>
-              val psaJsValue = Json.toJson(pensionSchemeAdministrator)
+              val psaJsValue = Json.toJson(pensionSchemeAdministrator)(PensionSchemeAdministrator.psaSubmissionWrites)
               Logger.debug(s"[PSA-Registration-Outgoing-Payload]${psaJsValue}")
 
               schemeConnector.registerPSA(psaJsValue).map {

--- a/app/models/PensionSchemeAdministrator.scala
+++ b/app/models/PensionSchemeAdministrator.scala
@@ -20,7 +20,7 @@ import java.time.LocalDate
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json
-import play.api.libs.json.{JsPath, JsResult, JsSuccess, JsValue, Json, Reads}
+import play.api.libs.json.{JsPath, JsResult, JsSuccess, JsValue, Json, Reads, Writes}
 
 trait PSADetail
 
@@ -113,6 +113,34 @@ case class DirectorOrPartnerDetailTypeItem(sequenceId: String, entityType: Strin
 object DirectorOrPartnerDetailTypeItem {
   implicit val formats = Json.format[DirectorOrPartnerDetailTypeItem]
 
+  val psaSubmissionWrites : Writes[DirectorOrPartnerDetailTypeItem] = (
+    (JsPath \ "sequenceId").write[String] and
+      (JsPath \ "entityType").write[String] and
+      (JsPath \ "title").writeNullable[String] and
+      (JsPath \ "firstName").write[String] and
+      (JsPath \ "middleName").writeNullable[String] and
+      (JsPath \ "lastName").write[String] and
+      (JsPath \ "dateOfBirth").write[LocalDate] and
+      (JsPath \ "referenceOrNino").writeNullable[String] and
+      (JsPath \ "noNinoReason").writeNullable[String] and
+      (JsPath \ "utr").writeNullable[String] and
+      (JsPath \ "noUtrReason").writeNullable[String] and
+      (JsPath \ "correspondenceCommonDetail").write[CorrespondenceCommonDetail] and
+      (JsPath \ "previousAddressDetail").write(PreviousAddressDetails.psaSubmissionWrites)
+  )(directorOrPartner => (directorOrPartner.sequenceId,
+    directorOrPartner.entityType,
+    directorOrPartner.title,
+    directorOrPartner.firstName,
+    directorOrPartner.middleName,
+    directorOrPartner.lastName,
+    directorOrPartner.dateOfBirth,
+    directorOrPartner.referenceOrNino,
+    directorOrPartner.noNinoReason,
+    directorOrPartner.utr,
+    directorOrPartner.noUtrReason,
+    directorOrPartner.correspondenceCommonDetail,
+    directorOrPartner.previousAddressDetail))
+
   val apiReads: Reads[List[DirectorOrPartnerDetailTypeItem]] = json.Reads {
     json =>
       json.validate[Seq[JsValue]].flatMap(elements => {
@@ -171,6 +199,38 @@ case class PensionSchemeAdministrator(customerType: String, legalStatus: String,
 
 object PensionSchemeAdministrator {
   implicit val formats = Json.format[PensionSchemeAdministrator]
+
+  val psaSubmissionWrites : Writes[PensionSchemeAdministrator] = (
+    (JsPath \ "customerType").write[String] and
+      (JsPath \ "legalStatus").write[String] and
+      (JsPath \ "idType").writeNullable[String] and
+      (JsPath \ "idNumber").writeNullable[String] and
+      (JsPath \ "sapNumber").write[String] and
+      (JsPath \ "noIdentifier").write[Boolean] and
+      (JsPath \ "organisationDetail").writeNullable[OrganisationDetailType] and
+      (JsPath \ "individualDetail").writeNullable[IndividualDetailType] and
+      (JsPath \ "pensionSchemeAdministratoridentifierStatus").write[PensionSchemeAdministratorIdentifierStatusType] and
+      (JsPath \ "correspondenceAddressDetail").write[Address] and
+      (JsPath \ "correspondenceContactDetail").write[ContactDetails] and
+      (JsPath \ "previousAddressDetail").write(PreviousAddressDetails.psaSubmissionWrites) and
+      (JsPath \ "numberOfDirectorOrPartners").writeNullable[NumberOfDirectorOrPartnersType] and
+      (JsPath \ "directorOrPartnerDetail").writeNullable[List[JsValue]] and
+      (JsPath \ "declaration").write[PensionSchemeAdministratorDeclarationType]
+  )(psaSubmission => (psaSubmission.customerType,
+  psaSubmission.legalStatus,
+  psaSubmission.idType,
+  psaSubmission.idNumber,
+  psaSubmission.sapNumber,
+  psaSubmission.noIdentifier,
+  psaSubmission.organisationDetail,
+  psaSubmission.individualDetail,
+  psaSubmission.pensionSchemeAdministratoridentifierStatus,
+  psaSubmission.correspondenceAddressDetail,
+  psaSubmission.correspondenceContactDetail,
+  psaSubmission.previousAddressDetail,
+  psaSubmission.numberOfDirectorOrPartners,
+  psaSubmission.directorOrPartnerDetail.map(directors => directors.map(director=>Json.toJson(director)(DirectorOrPartnerDetailTypeItem.psaSubmissionWrites))),
+  psaSubmission.declaration))
 
   val registrationInfoReads: Reads[(String, String, Boolean, String, Option[String], Option[String])] = (
     (JsPath \ "legalStatus").read[String] and

--- a/app/models/PensionsScheme.scala
+++ b/app/models/PensionsScheme.scala
@@ -17,7 +17,7 @@
 package models
 
 import models.enumeration.{Benefits, SchemeMembers, SchemeType}
-import play.api.libs.json.{Format, JsPath, Json, Reads}
+import play.api.libs.json.{Format, JsPath, Json, Reads, Writes}
 import play.api.libs.functional.syntax._
 import utils.Lens
 
@@ -35,10 +35,15 @@ object PersonalDetails {
 }
 
 case class PreviousAddressDetails(isPreviousAddressLast12Month: Boolean,
-                                  previousAddressDetail: Option[Address] = None)
+                                  previousAddressDetails: Option[Address] = None)
 
 object PreviousAddressDetails {
   implicit val formats: Format[PreviousAddressDetails] = Json.format[PreviousAddressDetails]
+
+  val psaSubmissionWrites : Writes[PreviousAddressDetails] = (
+    (JsPath \ "isPreviousAddressLast12Month").write[Boolean] and
+      (JsPath \ "previousAddressDetail").writeNullable[Address]
+    )(previousAddress => (previousAddress.isPreviousAddressLast12Month,previousAddress.previousAddressDetails))
 
   def apiReads(typeOfAddressDetail: String): Reads[PreviousAddressDetails] = (
     (JsPath \ s"${typeOfAddressDetail}AddressYears").read[String] and

--- a/test/models/Reads/PreviousAddressDetailReadsSpec.scala
+++ b/test/models/Reads/PreviousAddressDetailReadsSpec.scala
@@ -45,7 +45,7 @@ class PreviousAddressDetailReadsSpec extends WordSpec with MustMatchers with Opt
 
         val result = input.as[PreviousAddressDetails](PreviousAddressDetails.apiReads("company"))
 
-        result.previousAddressDetail.value.asInstanceOf[UkAddress].countryCode mustBe ukAddressSample.countryCode
+        result.previousAddressDetails.value.asInstanceOf[UkAddress].countryCode mustBe ukAddressSample.countryCode
       }
 
       "we have a non UK address with no postcode" in {
@@ -54,7 +54,7 @@ class PreviousAddressDetailReadsSpec extends WordSpec with MustMatchers with Opt
 
         val result = input.as[PreviousAddressDetails](PreviousAddressDetails.apiReads("company"))
 
-        result.previousAddressDetail.value.asInstanceOf[InternationalAddress].postalCode mustBe None
+        result.previousAddressDetails.value.asInstanceOf[InternationalAddress].postalCode mustBe None
       }
     }
   }

--- a/test/models/Reads/establishers/EstablishersTestData.scala
+++ b/test/models/Reads/establishers/EstablishersTestData.scala
@@ -97,7 +97,7 @@ object EstablishersTestData {
           Some(
             PreviousAddressDetails(
               isPreviousAddressLast12Month = true,
-              previousAddressDetail = Some(testAddress)
+              previousAddressDetails = Some(testAddress)
             )
           )
         }
@@ -136,7 +136,7 @@ object EstablishersTestData {
           Some(
             PreviousAddressDetails(
               isPreviousAddressLast12Month = true,
-              previousAddressDetail = Some(testAddress)
+              previousAddressDetails = Some(testAddress)
             )
           )
         }

--- a/test/models/Writes/DirectorOrPartnerDetailTypeItemWrites.scala
+++ b/test/models/Writes/DirectorOrPartnerDetailTypeItemWrites.scala
@@ -1,0 +1,17 @@
+package models.Writes
+
+import models.{DirectorOrPartnerDetailTypeItem, PreviousAddressDetails, Samples}
+import org.scalatest.{MustMatchers, OptionValues, WordSpec}
+import play.api.libs.json.Json
+
+class DirectorOrPartnerDetailTypeItemWrites extends WordSpec with MustMatchers with OptionValues with Samples {
+  "An object of a directorOrPartner detail type item" should {
+    "Map previosaddressdetails inner object as `previousaddresdetail`" when {
+      "required" in {
+        val result = Json.toJson(directorSample.copy(previousAddressDetail = PreviousAddressDetails(true,Some(ukAddressSample))))(DirectorOrPartnerDetailTypeItem.psaSubmissionWrites)
+
+        result.toString() must include("true,\"previousAddressDetail\":")
+      }
+    }
+  }
+}

--- a/test/models/Writes/DirectorOrPartnerDetailTypeItemWrites.scala
+++ b/test/models/Writes/DirectorOrPartnerDetailTypeItemWrites.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package models.Writes
 
 import models.{DirectorOrPartnerDetailTypeItem, PreviousAddressDetails, Samples}

--- a/test/models/Writes/PensionSchemeAdministratorWritesSpec.scala
+++ b/test/models/Writes/PensionSchemeAdministratorWritesSpec.scala
@@ -1,0 +1,25 @@
+package models.Writes
+
+import models.{PensionSchemeAdministrator, PreviousAddressDetails, Samples}
+import org.scalatest.{MustMatchers, OptionValues, WordSpec}
+import play.api.libs.json.Json
+
+class PensionSchemeAdministratorWritesSpec extends WordSpec with MustMatchers with OptionValues with Samples {
+  "An object of a Pension Scheme Administrator" should {
+    "Map all previousdetailsaddressess to `previousDetail`" when {
+      "We are doing a PSA submission containing previous address at rool level" in {
+        val result = Json.toJson(pensionSchemeAdministratorSample.copy(previousAddressDetail = PreviousAddressDetails(true,Some(ukAddressSample))))(PensionSchemeAdministrator.psaSubmissionWrites)
+
+        result.toString() must include("true,\"previousAddressDetail\":")
+      }
+
+      "We are doing a PSA submission with directors that have previous address" in {
+        val directorWithPreviousAddress = directorSample.copy(previousAddressDetail = PreviousAddressDetails(true,Some(ukAddressSample)))
+        val result = Json.toJson(pensionSchemeAdministratorSample.copy(directorOrPartnerDetail = Some(List(directorWithPreviousAddress))))(PensionSchemeAdministrator.psaSubmissionWrites)
+
+        println(result)
+        result.toString() must include("true,\"previousAddressDetail\":")
+      }
+    }
+  }
+}

--- a/test/models/Writes/PensionSchemeAdministratorWritesSpec.scala
+++ b/test/models/Writes/PensionSchemeAdministratorWritesSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package models.Writes
 
 import models.{PensionSchemeAdministrator, PreviousAddressDetails, Samples}

--- a/test/models/Writes/PreviousAddressDetailsWritesSpec.scala
+++ b/test/models/Writes/PreviousAddressDetailsWritesSpec.scala
@@ -1,0 +1,19 @@
+package models.Writes
+
+import models.{PreviousAddressDetails, Samples}
+import org.scalatest.{MustMatchers, OptionValues, WordSpec}
+import play.api.libs.json.Json
+
+class PreviousAddressDetailsWritesSpec extends WordSpec with MustMatchers with OptionValues with Samples{
+
+  "A previous address details object" should {
+    "Map previosaddressdetails inner object as `previousaddresdetail`" when {
+      "required" in {
+        val previousAddress = PreviousAddressDetails(true,Some(ukAddressSample))
+        val result = Json.toJson(previousAddress)(PreviousAddressDetails.psaSubmissionWrites)
+
+        result.toString() must include("\"previousAddressDetail\":")
+      }
+    }
+  }
+}

--- a/test/models/Writes/PreviousAddressDetailsWritesSpec.scala
+++ b/test/models/Writes/PreviousAddressDetailsWritesSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package models.Writes
 
 import models.{PreviousAddressDetails, Samples}


### PR DESCRIPTION
This PR is to be able to handle inconsistencies in DES schema when creating a previousAddressDetail. 
If we are submitting a scheme the structure is previousAddressDetail { ..., previousAddressDetails : ...}
If we are submitting a psa then the structure is previousAddressDetail { ..., previousAddressDetail : ...}