### PR TITLE
PODS-2754: Downgrade reactivemongo to 7.16.0-play-26

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -31,7 +31,7 @@ object AppDependencies {
   private val bootstrapVersion = "0.40.0"
   private val playJsonVersion = "2.6.10"
   private val scalaTestVersion = "3.0.5"
-  private val reactiveMongoVersion = "7.19.0-play-26"
+  private val reactiveMongoVersion = "7.16.0-play-26"
   private val jsonSchemeValidatorVersion = "1.0.3"
   private val jsonPathVersion = "2.6.0"
   private val reactiveMongoTestVersion = "4.14.0-play-26"


### PR DESCRIPTION
Downgraded reacrivemongo version to 7.16 to determine if this is what's causing the memory leak (investigated with Wolfy and looking at other services this could be the issue) Need to deploy up to production and monitor Grafana to see what the memory does.